### PR TITLE
An adjustment for outputSizes larger than the natural video size.

### DIFF
--- a/MultiVidCam/VideoCameraInputManager.m
+++ b/MultiVidCam/VideoCameraInputManager.m
@@ -244,13 +244,17 @@
             CGFloat ratioH = videoSize.height / videoTrack.naturalSize.height;
             if(ratioW < ratioH)
             {
+                // When the ratios are larger than one, we must flip the translation.
+                float neg = (ratioH > 1.0) ? 1.0 : -1.0;
                 CGFloat diffH = videoTrack.naturalSize.height - (videoTrack.naturalSize.height * ratioH);
-                return CGAffineTransformConcat( CGAffineTransformMakeTranslation(0, -diffH/2.0), CGAffineTransformMakeScale(ratioH, ratioH) );
+                return CGAffineTransformConcat( CGAffineTransformMakeTranslation(0, neg*diffH/2.0), CGAffineTransformMakeScale(ratioH, ratioH) );
             }
             else
             {
+                // When the ratios are larger than one, we must flip the translation.
+                float neg = (ratioW > 1.0) ? 1.0 : -1.0;
                 CGFloat diffW = videoTrack.naturalSize.width - (videoTrack.naturalSize.width * ratioW);
-                return CGAffineTransformConcat( CGAffineTransformMakeTranslation(-diffW/2.0, 0), CGAffineTransformMakeScale(ratioW, ratioW) );
+                return CGAffineTransformConcat( CGAffineTransformMakeTranslation(neg*diffW/2.0, 0), CGAffineTransformMakeScale(ratioW, ratioW) );
             }
             
         } withErrorHandler:^(NSError *error) {


### PR DESCRIPTION
In the case where your videoSize is larger than the naturalSize, you must flip the translation in the CGAffineTransform. Updated code to account for this.
